### PR TITLE
Rename KV workspace AMP_EXP to CONFIG

### DIFF
--- a/jestconfig.json
+++ b/jestconfig.json
@@ -1,7 +1,7 @@
 {
   "preset": "ts-jest",
   "globals": {
-    "AMP_EXP": null,
+    "CONFIG": null,
     "RTV": null
   }
 }

--- a/src/injectors.ts
+++ b/src/injectors.ts
@@ -5,7 +5,7 @@
 import {KV, read} from 'worktop/kv';
 
 // KV Binding via `wrangler.toml` config.
-declare const AMP_EXP: KV.Namespace;
+declare const CONFIG: KV.Namespace;
 
 interface AmpExp {
   experiments: Array<{
@@ -26,7 +26,7 @@ export async function injectAmpExp(
   response: Response,
   rtv: string
 ): Promise<Response> {
-  const ampExpConfig = await read<AmpExp>(AMP_EXP, 'AMP_EXP', {type: 'json'});
+  const ampExpConfig = await read<AmpExp>(CONFIG, 'AMP_EXP', {type: 'json'});
   if (!ampExpConfig) {
     console.warn('AMP_EXP config is missing from KV store, skipping injection');
     return response;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,7 +6,7 @@ route = ""
 workers_dev = true
 kv_namespaces = [
   { binding = "RTV", id = "f33b97f2e1434004975c0d8553f70488", preview_id = "192df3dff1b345ce8e7c794329bb7ccd" },
-  { binding = "AMP_EXP", id = "b03e5db05f3e4d068508da267e248949", preview_id = "69318ded67c0477b85d73ec801b47543" }
+  { binding = "CONFIG", id = "b03e5db05f3e4d068508da267e248949", preview_id = "69318ded67c0477b85d73ec801b47543" }
 ]
 
 [build]


### PR DESCRIPTION
This is to differentiate the configuration workspace from the single value AMP_EXP (which is a stringified .json file). This can be done asynchronously from the change in Cloudflare itself because the binding is performed based on the ID (see `wrangler.toml`) and not based on the name itself - so this is really just a cosmetic change to the code