### PR TITLE
Fix incorrect opt-in logic for beta/experimental channels

### DIFF
--- a/src/rtv.ts
+++ b/src/rtv.ts
@@ -30,7 +30,8 @@ const CHANNELS_WITH_OPT_IN_SUFFIX: ReadonlySet<string> = new Set([
 
 /**
  * Adds an `-opt-in` suffix to opt in channels that require it.
- * @param channel -
+ * @param channel - name of a channel that might require an `-opt-in` suffix.
+ * @returns the passed in `channel`, or or `channel` + '-opt-in'.
  */
 function maybeAddOptInSuffix(channel: string | null): string | null {
   return channel && CHANNELS_WITH_OPT_IN_SUFFIX.has(channel)

--- a/src/rtv.ts
+++ b/src/rtv.ts
@@ -27,12 +27,22 @@ export enum Channel {
  * @returns the chosen RTV.
  */
 export async function chooseRtv(request: ServerRequest): Promise<string> {
-  // Choose which channel to opt in to based on the following order:
+  const optInCookie = Cookie.parse(request.headers.get('cookie') ?? '')[
+    '__Host-AMP_OPT_IN'
+  ];
+  const optInQueryParam = request.query.get('optin');
+
+  // Choose which channel to opt in to based on the following order. Note that
+  // some channels have a separation between `-opt-in` and `-traffic`, so we
+  // also attempt to fetch `${channel}-opt-in` when `${channel}` is passed via
+  // cookie/query param.
   const channelChooser = [
     // Opt-in cookie value:
-    Cookie.parse(request.headers.get('cookie') ?? '')['__Host-AMP_OPT_IN'],
+    optInCookie,
+    optInCookie && `${optInCookie}-opt-in`,
     // Query param (?optin=channel-name):
-    request.query.get('optin'),
+    optInQueryParam,
+    optInQueryParam && `${optInQueryParam}-opt-in`,
     // LTS request:
     request.path.startsWith('/lts') && Channel.LTS,
     // Default to Stable:

--- a/test/rtv.test.ts
+++ b/test/rtv.test.ts
@@ -109,8 +109,7 @@ describe('rtv', () => {
     );
 
     expect(rtv).toEqual('032105190310001');
-    expect(readMock).toHaveBeenCalledTimes(2);
-    expect(readMock).toHaveBeenCalledWith(null, 'beta', opts);
+    expect(readMock).toHaveBeenCalledTimes(1);
     expect(readMock).toHaveBeenCalledWith(null, 'beta-opt-in', opts);
   });
 
@@ -120,8 +119,7 @@ describe('rtv', () => {
     );
 
     expect(rtv).toEqual('002105190310001');
-    expect(readMock).toHaveBeenCalledTimes(2);
-    expect(readMock).toHaveBeenCalledWith(null, 'experimental', opts);
+    expect(readMock).toHaveBeenCalledTimes(1);
     expect(readMock).toHaveBeenCalledWith(null, 'experimental-opt-in', opts);
   });
 
@@ -131,8 +129,7 @@ describe('rtv', () => {
     );
 
     expect(rtv).toEqual('002105190310001');
-    expect(readMock).toHaveBeenCalledTimes(2);
-    expect(readMock).toHaveBeenCalledWith(null, 'experimental', opts);
+    expect(readMock).toHaveBeenCalledTimes(1);
     expect(readMock).toHaveBeenCalledWith(null, 'experimental-opt-in', opts);
   });
 
@@ -151,12 +148,10 @@ describe('rtv', () => {
     );
 
     expect(rtv).toEqual('012105150310000');
-    expect(readMock).toHaveBeenCalledTimes(5);
+    expect(readMock).toHaveBeenCalledTimes(3);
     expect(readMock).toHaveBeenNthCalledWith(1, null, 'doggies', opts);
-    expect(readMock).toHaveBeenNthCalledWith(2, null, 'doggies-opt-in', opts);
-    expect(readMock).toHaveBeenNthCalledWith(3, null, 'kittens', opts);
-    expect(readMock).toHaveBeenNthCalledWith(4, null, 'kittens-opt-in', opts);
-    expect(readMock).toHaveBeenNthCalledWith(5, null, 'stable', opts);
+    expect(readMock).toHaveBeenNthCalledWith(2, null, 'kittens', opts);
+    expect(readMock).toHaveBeenNthCalledWith(3, null, 'stable', opts);
   });
 
   it('raises an error if no RTVs were undefined', async () => {
@@ -168,12 +163,10 @@ describe('rtv', () => {
       )
     ).rejects.toThrowError('No available RTV');
 
-    expect(readMock).toHaveBeenCalledTimes(6);
+    expect(readMock).toHaveBeenCalledTimes(4);
     expect(readMock).toHaveBeenNthCalledWith(1, null, 'nightly', opts);
-    expect(readMock).toHaveBeenNthCalledWith(2, null, 'nightly-opt-in', opts);
-    expect(readMock).toHaveBeenNthCalledWith(3, null, 'beta', opts);
-    expect(readMock).toHaveBeenNthCalledWith(4, null, 'beta-opt-in', opts);
-    expect(readMock).toHaveBeenNthCalledWith(5, null, 'lts', opts);
-    expect(readMock).toHaveBeenNthCalledWith(6, null, 'stable', opts);
+    expect(readMock).toHaveBeenNthCalledWith(2, null, 'beta-opt-in', opts);
+    expect(readMock).toHaveBeenNthCalledWith(3, null, 'lts', opts);
+    expect(readMock).toHaveBeenNthCalledWith(4, null, 'stable', opts);
   });
 });


### PR DESCRIPTION
In versions.json we store RTV data for 4 channels: {`beta`,`experimental`} × {`-opt-in`,`-traffic`} - the opt-in logic was unaware of this distinction, so opting in to the "flat" channels such as `nightly`, `experimentA` worked, but `beta`/`experimental` didn't

This is my quick fix, don't know how happy I am with that though. wdyt?