### PR TITLE
Replace `application/javascript` with `text/javascript; charset=UTF-8` in responses

### DIFF
--- a/src/headers.ts
+++ b/src/headers.ts
@@ -34,7 +34,31 @@ export enum CacheControl {
 }
 
 export enum ContentType {
+  APPLICATION_JAVASCRIPT = 'application/javascript',
   APPLICATION_JSON = 'application/json; charset=UTF-8',
+  TEXT_JAVASCRIPT = 'text/javascript; charset=UTF-8',
+  TEXT_PLAIN = 'text/plain; charset=UTF-8',
+}
+
+/**
+ * Chooses the Content-Type of the output based on the input response's value.
+ *
+ * * Overrides `application/javascript` to `text/javascript; UTF-8`
+ * * If defined, uses the input response's Content-Type directly,
+ * * Otherwise fallbacks back to `text/plain; charset=UTF-8`
+ *
+ * @param inputContentType - value of the input response's Content-Type header.
+ */
+function chooseContentType(inputContentType: string | null): string {
+  if (inputContentType === ContentType.APPLICATION_JAVASCRIPT) {
+    return ContentType.TEXT_JAVASCRIPT;
+  }
+
+  if (inputContentType) {
+    return inputContentType;
+  }
+
+  return ContentType.TEXT_PLAIN;
 }
 
 /**
@@ -56,10 +80,10 @@ export function withHeaders(
 ): Response {
   const response = new Response(inputResponse.body);
 
-  // Set Content-Type to the the input response's original value, or fallback
-  // to 'text/plain'. Note that this could also get overridden via extraHeaders.
-  const contentType =
-    inputResponse.headers.get(HeaderKeys.CONTENT_TYPE) ?? 'text/plain';
+  // Note that this could also get overridden via extraHeaders.
+  const contentType = chooseContentType(
+    inputResponse.headers.get(HeaderKeys.CONTENT_TYPE)
+  );
 
   response.headers.set(HeaderKeys.CACHE_CONTROL, cacheControl);
   response.headers.set(HeaderKeys.CONTENT_TYPE, contentType);

--- a/test/headers.test.ts
+++ b/test/headers.test.ts
@@ -17,7 +17,10 @@ describe('headers', () => {
 
   it('responds with headers', async () => {
     const inputResponse = new Response('alert("!");', {
-      headers: {'Content-Type': 'text/javascript', 'X-Other-Header': 'kittens'},
+      headers: {
+        'Content-Type': 'application/javascript',
+        'X-Other-Header': 'kittens',
+      },
       status: 200,
     });
 
@@ -28,7 +31,7 @@ describe('headers', () => {
     expect(Object.fromEntries(outputResponse.headers)).toMatchObject({
       'access-control-allow-origin': '*',
       'cache-control': 'private, max-age=604800, stale-while-revalidate=604800',
-      'content-type': 'text/javascript',
+      'content-type': 'text/javascript; charset=UTF-8',
       'cross-origin-resource-policy': 'cross-origin',
       'strict-transport-security':
         'max-age=31536000; includeSubDomains; preload',
@@ -40,7 +43,7 @@ describe('headers', () => {
 
   it('adds extra headers', () => {
     const inputResponse = new Response('alert("!");', {
-      headers: {'Content-Type': 'text/javascript'},
+      headers: {'Content-Type': 'application/javascript'},
     });
 
     const outputResponse = withHeaders(
@@ -83,7 +86,7 @@ describe('headers', () => {
 
     expect(Object.fromEntries(outputResponse.headers)).toMatchObject(
       expect.objectContaining({
-        'content-type': 'text/plain',
+        'content-type': 'text/plain; charset=UTF-8',
       })
     );
   });


### PR DESCRIPTION
This should fix an encoding issue where non-ascii characters are mis-parsed. e.g., there are two variable in v0.mjs that sets a string to be 3 and 4 NBSPs respective (don't ask me why, that's just something in v0.mjs...):

```
rodaniel@rodaniel08:~$ hexyl --skip 4360 --length 100 v0.mjs 
┌────────┬─────────────────────────┬─────────────────────────┬────────┬────────┐
│00001108│ 7d 76 61 72 20 78 3d 22 ┊ e2 80 8b e2 80 8b e2 80 │}var x="┊××××××××│
│00001118│ 8b 22 2c 4f 3d 22 e2 80 ┊ 8b e2 80 8b e2 80 8b e2 │×",O="××┊××××××××│
│00001128│ 80 8b 22 3b 66 75 6e 63 ┊ 74 69 6f 6e 20 43 28 74 │××";func┊tion C(t│
│00001138│ 29 7b 72 65 74 75 72 6e ┊ 20 56 28 74 29 3f 28 74 │){return┊ V(t)?(t│
│00001148│ 3d 74 29 2e 74 61 67 4e ┊ 61 6d 65 2e 74 6f 4c 6f │=t).tagN┊ame.toLo│
│00001158│ 77 65 72 43 61 73 65 28 ┊ 29 2b 28 74 2e 69 64 3f │werCase(┊)+(t.id?│
│00001168│ 60 23 24 7b             ┊                         │`#${    ┊        │
└────────┴─────────────────────────┴─────────────────────────┴────────┴────────┘
```

Without this fix this section renders in browsers as ```}var x="â€‹â€‹â€‹",O="â€‹â€‹â€‹â€‹";function C(t){return V(t)?(t=t).tagName.toLowerCase()+(t.id?`#${```, after this fix it comes out ```}var x="​​​",O="​​​​";function C(t){return V(t)?(t=t).tagName.toLowerCase()+(t.id?`#${```