### PR TITLE
Add partial support for passing through Brotli pre-compressed files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -85,7 +85,6 @@
     "no-unused-expressions": 0,
     "no-useless-call": 2,
     "no-useless-concat": 2,
-    "no-undef": 2,
     "no-var": 2,
     "object-shorthand": [
       2,

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -13,6 +13,7 @@ const SHARED_HEADERS: ReadonlyMap<string, string> = new Map([
 
 export enum HeaderKeys {
   CACHE_CONTROL = 'Cache-Control',
+  CONTENT_ENCODING = 'Content-Encoding',
   CONTENT_SECURITY_POLICY = 'Content-Security-Policy',
   CONTENT_TYPE = 'Content-Type',
   X_FRAME_OPTIONS = 'X-Frame-Options',
@@ -65,7 +66,7 @@ function chooseContentType(inputContentType: string | null): string {
  * Creates a new Response object with default HTTP headers.
  *
  * Drops all existing HTTP headers on the input response, except for the
- * Content-Type header which is kept. Note that Content-Type can be overridden
+ * Content-Encoding/Type headers which are kept. These headers can be overridden
  * using the `extraHeaders` parameter.
  *
  * @param inputResponse - object to add headers to.
@@ -80,12 +81,18 @@ export function withHeaders(
 ): Response {
   const response = new Response(inputResponse.body);
 
-  // Note that this could also get overridden via extraHeaders.
+  // Note that these could be overridden via extraHeaders.
+  const contentEncoding = inputResponse.headers.get(
+    HeaderKeys.CONTENT_ENCODING
+  );
   const contentType = chooseContentType(
     inputResponse.headers.get(HeaderKeys.CONTENT_TYPE)
   );
 
   response.headers.set(HeaderKeys.CACHE_CONTROL, cacheControl);
+  if (contentEncoding) {
+    response.headers.set(HeaderKeys.CONTENT_ENCODING, contentEncoding);
+  }
   response.headers.set(HeaderKeys.CONTENT_TYPE, contentType);
 
   [...SHARED_HEADERS, ...(extraHeaders ?? [])].forEach(([header, value]) => {

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -41,6 +41,10 @@ export enum ContentType {
   TEXT_PLAIN = 'text/plain; charset=UTF-8',
 }
 
+export enum ContentEncoding {
+  BROTLI = 'br',
+}
+
 /**
  * Chooses the Content-Type of the output based on the input response's value.
  *

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -2,7 +2,7 @@
  * Contains functions that interact with the backing storage.
  */
 
-import {IncomingCloudflareProperties} from 'worktop/request';
+import type {IncomingCloudflareProperties} from 'worktop/request';
 
 import {FetchError} from './errors';
 import {HeaderKeys} from './headers';

--- a/test/headers.test.ts
+++ b/test/headers.test.ts
@@ -39,6 +39,34 @@ describe('headers', () => {
       'x-content-type-options': 'nosniff',
       'x-xss-protection': '0',
     });
+    expect(outputResponse.headers.has('x-other-header')).toBe(false);
+    expect(outputResponse.headers.has('X-Other-Header')).toBe(false);
+  });
+
+  it('does not add content-encoding if none was specified in input', async () => {
+    const inputResponse = new Response(Uint8Array.from([0x00, 0x01, 0x02]), {
+      headers: {},
+      status: 200,
+    });
+
+    const outputResponse = withHeaders(inputResponse, CacheControl.DEFAULT);
+
+    expect(outputResponse.headers.has('content-encoding')).toBe(false);
+  });
+
+  it('keeps content-encoding header', async () => {
+    const inputResponse = new Response(Uint8Array.from([0x00, 0x01, 0x02]), {
+      headers: {
+        'Content-Encoding': 'br',
+      },
+      status: 200,
+    });
+
+    const outputResponse = withHeaders(inputResponse, CacheControl.DEFAULT);
+
+    expect(Object.fromEntries(outputResponse.headers)).toMatchObject({
+      'content-encoding': 'br',
+    });
   });
 
   it('adds extra headers', () => {

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -52,7 +52,7 @@ function makeFetchEvent(path: string): FetchEvent {
       url: `https://example.com${path}`,
       // @ts-expect-error ignore missing fields, we only care about these ones.
       cf: {
-        country: 'br',
+        country: 'nl',
       },
 
       // We don't care about these fields, but they are used by the constructor
@@ -153,7 +153,8 @@ describe('router', () => {
 
       expect(fetchImmutableAmpFileOrDieMock).toHaveBeenCalledWith(
         '012105150310000',
-        '/v0.js'
+        '/v0.js',
+        {country: 'nl'}
       );
     });
 
@@ -184,7 +185,7 @@ describe('router', () => {
       );
       expect(injectAmpGeoMock).toHaveBeenCalledWith(
         expect.any(Response),
-        'br',
+        'nl',
         undefined
       );
     });
@@ -252,7 +253,7 @@ describe('router', () => {
         );
         expect(injectAmpGeoMock).toHaveBeenCalledWith(
           expect.any(Response),
-          'br',
+          'nl',
           undefined
         );
       }
@@ -282,7 +283,8 @@ describe('router', () => {
 
         expect(fetchImmutableAmpFileOrDieMock).toHaveBeenCalledWith(
           '012105150310000',
-          path
+          path,
+          {'country': 'nl'}
         );
       }
     );
@@ -305,7 +307,8 @@ describe('router', () => {
 
         expect(fetchImmutableAmpFileOrDieMock).toHaveBeenCalledWith(
           '012105150310000',
-          path
+          path,
+          {'country': 'nl'}
         );
         expect(injectAmpExpMock).not.toHaveBeenCalled();
       }
@@ -331,7 +334,8 @@ describe('router', () => {
 
         expect(fetchImmutableAmpFileOrDieMock).toHaveBeenCalledWith(
           '012105150310000',
-          path
+          path,
+          {'country': 'nl'}
         );
       }
     );
@@ -358,7 +362,8 @@ describe('router', () => {
 
       expect(fetchImmutableAmpFileOrDieMock).toHaveBeenCalledWith(
         '012105150310000',
-        path
+        path,
+        {'country': 'nl'}
       );
     });
   });

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -3,6 +3,7 @@
  */
 
 import {disableFetchMocks, enableFetchMocks} from 'jest-fetch-mock';
+import {IncomingCloudflareProperties} from 'worktop/request';
 
 import {FetchError} from '../src/errors';
 import {
@@ -25,7 +26,7 @@ describe('storage', () => {
 
   describe('fetchImmutableUrlOrDie', () => {
     it('fetchs an arbitrary URL', async () => {
-      fetchMock.mockResponse('Kittens.', {status: 200});
+      fetchMock.once('Kittens.', {status: 200});
 
       const response = await fetchImmutableUrlOrDie(
         'https://example.com/kittens.txt'
@@ -33,15 +34,80 @@ describe('storage', () => {
 
       await expect(response.text()).resolves.toEqual('Kittens.');
       expect(response.status).toEqual(200);
+      expect(response.headers.get('Content-Encoding')).toBeNull();
 
       expect(fetch).toHaveBeenCalledTimes(1);
       expect(fetch).toHaveBeenCalledWith('https://example.com/kittens.txt', {
-        'cf': {'cacheEverything': true, 'cacheTtl': 31536000},
+        cf: {cacheEverything: true, cacheTtl: 31536000},
       });
     });
 
+    it('fetchs an arbitrary URL with Brotli', async () => {
+      fetchMock.once('Kittens.', {status: 200});
+      fetchMock.once('ktnṡ', {status: 200});
+
+      const response = await fetchImmutableUrlOrDie(
+        'https://example.com/kittens.txt',
+        {
+          clientAcceptEncoding: 'gzip, deflate, br',
+        } as unknown as IncomingCloudflareProperties
+      );
+
+      await expect(response.text()).resolves.toEqual('ktnṡ');
+      expect(response.status).toEqual(200);
+      expect(response.headers.get('Content-Encoding')).toEqual('br');
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(fetch).toHaveBeenNthCalledWith(
+        1,
+        'https://example.com/kittens.txt',
+        {
+          cf: {cacheEverything: true, cacheTtl: 31536000},
+        }
+      );
+      expect(fetch).toHaveBeenNthCalledWith(
+        2,
+        'https://example.com/kittens.txt.br',
+        {
+          cf: {cacheEverything: true, cacheTtl: 31536000},
+        }
+      );
+    });
+
+    it('falls back to plain response when Brotli files does not exists in storage', async () => {
+      fetchMock.once('Kittens.', {status: 200});
+      fetchMock.once('404 Not Found', {status: 404});
+
+      const response = await fetchImmutableUrlOrDie(
+        'https://example.com/kittens.txt',
+        {
+          clientAcceptEncoding: 'gzip, deflate, br',
+        } as unknown as IncomingCloudflareProperties
+      );
+
+      await expect(response.text()).resolves.toEqual('Kittens.');
+      expect(response.status).toEqual(200);
+      expect(response.headers.get('Content-Encoding')).toBeNull();
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(fetch).toHaveBeenNthCalledWith(
+        1,
+        'https://example.com/kittens.txt',
+        {
+          cf: {cacheEverything: true, cacheTtl: 31536000},
+        }
+      );
+      expect(fetch).toHaveBeenNthCalledWith(
+        2,
+        'https://example.com/kittens.txt.br',
+        {
+          cf: {cacheEverything: true, cacheTtl: 31536000},
+        }
+      );
+    });
+
     it('throws an error when the response is not 200 OK', async () => {
-      fetchMock.mockResponse('Kittens.', {status: 404});
+      fetchMock.once('Kittens.', {status: 404});
 
       await expect(() =>
         fetchImmutableUrlOrDie('https://example.com/kittens.txt')
@@ -49,14 +115,14 @@ describe('storage', () => {
 
       expect(fetch).toHaveBeenCalledTimes(1);
       expect(fetch).toHaveBeenCalledWith('https://example.com/kittens.txt', {
-        'cf': {'cacheEverything': true, 'cacheTtl': 31536000},
+        cf: {cacheEverything: true, cacheTtl: 31536000},
       });
     });
   });
 
   describe('fetchImmutableAmpFileOrDie', () => {
     it('fetches an AMP file', async () => {
-      fetchMock.mockResponse('…var global=self;…', {status: 200});
+      fetchMock.once('…var global=self;…', {status: 200});
 
       const response = await fetchImmutableAmpFileOrDie(
         '002105150310000',
@@ -70,13 +136,13 @@ describe('storage', () => {
       expect(fetch).toHaveBeenCalledWith(
         'https://storage.googleapis.com/org-cdn/org-cdn/rtv/002105150310000/v0.js',
         {
-          'cf': {'cacheEverything': true, 'cacheTtl': 31536000},
+          cf: {cacheEverything: true, cacheTtl: 31536000},
         }
       );
     });
 
     it('fetches an LTS AMP file', async () => {
-      fetchMock.mockResponse('…var global=self;…', {status: 200});
+      fetchMock.once('…var global=self;…', {status: 200});
 
       const response = await fetchImmutableAmpFileOrDie(
         '002105150310000',
@@ -90,7 +156,7 @@ describe('storage', () => {
       expect(fetch).toHaveBeenCalledWith(
         'https://storage.googleapis.com/org-cdn/org-cdn/rtv/002105150310000/v0.js',
         {
-          'cf': {'cacheEverything': true, 'cacheTtl': 31536000},
+          cf: {cacheEverything: true, cacheTtl: 31536000},
         }
       );
     });
@@ -114,7 +180,7 @@ describe('storage', () => {
     ])(
       'v0/ requests to a %s-prefix file should serve the %s-prefix file',
       async (requestedRtvPrefix, expectedRtvPrefix) => {
-        fetchMock.mockResponse('…var global=self;…', {status: 200});
+        fetchMock.once('…var global=self;…', {status: 200});
 
         const response = await fetchImmutableAmpFileOrDie(
           `${requestedRtvPrefix}2105150310000`,
@@ -128,7 +194,7 @@ describe('storage', () => {
         expect(fetch).toHaveBeenCalledWith(
           `https://storage.googleapis.com/org-cdn/org-cdn/rtv/${expectedRtvPrefix}2105150310000/v0/amp-list-0.1.js`,
           {
-            'cf': {'cacheEverything': true, 'cacheTtl': 31536000},
+            cf: {cacheEverything: true, cacheTtl: 31536000},
           }
         );
       }
@@ -153,7 +219,7 @@ describe('storage', () => {
     ])(
       'lts/v0/ requests to a %s-prefix file should serve the %s-prefix file',
       async (requestedRtvPrefix, expectedRtvPrefix) => {
-        fetchMock.mockResponse('…var global=self;…', {status: 200});
+        fetchMock.once('…var global=self;…', {status: 200});
 
         const response = await fetchImmutableAmpFileOrDie(
           `${requestedRtvPrefix}2105150310000`,
@@ -167,7 +233,7 @@ describe('storage', () => {
         expect(fetch).toHaveBeenCalledWith(
           `https://storage.googleapis.com/org-cdn/org-cdn/rtv/${expectedRtvPrefix}2105150310000/v0/amp-list-0.1.js`,
           {
-            'cf': {'cacheEverything': true, 'cacheTtl': 31536000},
+            cf: {cacheEverything: true, cacheTtl: 31536000},
           }
         );
       }


### PR DESCRIPTION
Partial for #91

You can test various links in the preview URL, e.g.: https://empty-butterfly-fee6.rodaniel-test1.workers.dev/rtv/012202092050000/v0/amp-list-0.1.mjs
(this preview uses a test storage instance, which only has files for RTV `012202092050000`)

For now only non-dynamic requests benefit from this, which leaves out the entry files (`/v0.[m]js`, `/amp4ads-v0.[m]js`, etc.) and any amp-geo request