### PR TITLE
Explicitly set each environment name in wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,10 +1,10 @@
-name = "cdn-worker"
 type = "javascript"
 zone_id = "31ef5324904df8e826d642e739af38f8"
 account_id = "78e1d5140b47fc9dab18dc8b25351b7a"
 compatibility_date = "2022-02-25"
 
 [env.production]
+name = "cdn-worker"
 route = "ampjs.org/*"
 kv_namespaces = [
   { binding = "RTV", id = "f33b97f2e1434004975c0d8553f70488", preview_id = "192df3dff1b345ce8e7c794329bb7ccd" },
@@ -12,6 +12,7 @@ kv_namespaces = [
 ]
 
 [env.staging]
+name = "cdn-worker-staging"
 workers_dev = true
 kv_namespaces = [
   { binding = "RTV", id = "f33b97f2e1434004975c0d8553f70488", preview_id = "192df3dff1b345ce8e7c794329bb7ccd" },
@@ -19,6 +20,7 @@ kv_namespaces = [
 ]
 
 [env.development]
+name = "cdn-worker-development"
 workers_dev = true
 kv_namespaces = [
   { binding = "RTV", id = "192df3dff1b345ce8e7c794329bb7ccd", preview_id = "192df3dff1b345ce8e7c794329bb7ccd" },


### PR DESCRIPTION
Otherwise `wrangler publish --env production` creates a new service in Cloudflare named `cdn-worker-production`

This also has the added advantage that it forces you to specify the environment instead of defaulting to `production`. No accidental push-to-prods here!