### PR TITLE
Updates to match changes in Cloudflare/Wrangler infrastructure

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -5,7 +5,7 @@ const textReplacePlugin = require('esbuild-plugin-text-replace');
 esbuild
   .build({
     bundle: true,
-    outfile: 'dist/worker.js',
+    outfile: 'dist/worker.mjs',
     entryPoints: ['src/index.ts'],
     plugins: [
       ignorePlugin([
@@ -14,7 +14,7 @@ esbuild
         },
       ]),
       textReplacePlugin({
-        include: /brotli_wasm(?:_bg?)\.js$/,
+        include: /brotli_wasm(?:_bg)?\.js$/,
         pattern: [
           ["import * as wasm from './brotli_wasm_bg.wasm';", ''],
           ['wasm.', 'globalThis.__BROTLI_WASM_INSTANCE.'],
@@ -22,7 +22,7 @@ esbuild
       }),
     ],
     sourcemap: true,
-    format: 'cjs',
+    format: 'esm',
     logLevel: 'info',
   })
   .catch(() => process.exit(1));

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "amp-cdn-worker",
   "version": "1.0.0",
   "description": "Cloudflare Worker code for the AMP runtime CDN",
-  "main": "dist/worker.js",
+  "main": "dist/worker.mjs",
   "scripts": {
     "build": "node ./esbuild.js",
     "format": "prettier --write  '*.{json,js}' 'src/**/*.{js,ts}' 'test/**/*.{js,ts}'",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,8 @@
-type = "javascript"
-zone_id = "31ef5324904df8e826d642e739af38f8"
+main = "./dist/worker.mjs"
+compatibility_date = "2022-12-08"
 account_id = "78e1d5140b47fc9dab18dc8b25351b7a"
-compatibility_date = "2022-02-25"
+usage_model = "unbound"
+no_bundle = true
 
 [env.production]
 name = "cdn-worker"
@@ -28,9 +29,8 @@ kv_namespaces = [
 ]
 
 [wasm_modules]
-BROTLI_WASM = 'node_modules/brotli-wasm/pkg.bundler/brotli_wasm_bg.wasm'
+BROTLI_WASM = "node_modules/brotli-wasm/pkg.bundler/brotli_wasm_bg.wasm"
 
 [build]
 command = "npm ci && npm run build"
-[build.upload]
-format = "service-worker"
+watch_dir = "src"


### PR DESCRIPTION
* `zone_id` has been deprecated
* nomodule code cannot use WASM anymore, so switch compilation mode to .mjs
* explicitly set `usage_model = "unbound"` to allow requests to live longer than 50 ms
* set `no_bundle = true` since we already have our own compilation step
