### PR TITLE
Use `(dev|staging).ampjs.org` for dev/staging environments

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -17,7 +17,7 @@ STORAGE_BASE_URL = "https://pub-857751ce270b4ed4b8b5a2baa3212e8d.r2.dev/org-cdn/
 
 [env.staging]
 name = "cdn-worker-staging"
-workers_dev = true
+route = "staging.ampjs.org/*"
 kv_namespaces = [
   { binding = "RTV", id = "f33b97f2e1434004975c0d8553f70488", preview_id = "192df3dff1b345ce8e7c794329bb7ccd" },
   { binding = "CONFIG", id = "b03e5db05f3e4d068508da267e248949", preview_id = "69318ded67c0477b85d73ec801b47543" }
@@ -28,7 +28,7 @@ STORAGE_BASE_URL = "https://pub-857751ce270b4ed4b8b5a2baa3212e8d.r2.dev/org-cdn/
 
 [env.development]
 name = "cdn-worker-development"
-workers_dev = true
+route = "dev.ampjs.org/*"
 kv_namespaces = [
   { binding = "RTV", id = "192df3dff1b345ce8e7c794329bb7ccd", preview_id = "192df3dff1b345ce8e7c794329bb7ccd" },
   { binding = "CONFIG", id = "69318ded67c0477b85d73ec801b47543", preview_id = "69318ded67c0477b85d73ec801b47543" }


### PR DESCRIPTION
Finally managed to figure out how to set up the dev/staging subdomains, so let's redirect those environments in Cloudflare :)